### PR TITLE
Removing unnecessary logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,17 +57,13 @@ app.listen(PORT, "localhost", () => {
 });
 
 const register = () => {
-	console.log("Registering with DBS...")
 	axios.post(`${process.env.DBS_URI}/register`, {
 		type: "arweave",
 		description: "File storage on Arweave",
 		url: process.env.SELF_URI,
 		payment: getAcceptedPaymentDetails(),
 	})
-	.then((response) => {
-		console.log(response);
-	})
 	.catch((error) => {
-		console.error(error);
+		console.error('Error registering with DBS:', error);
 	})
 }


### PR DESCRIPTION
Constantly logging every register request sent and the full response creates a lot of noise. We only need to log this when there is an error. 